### PR TITLE
Direct map physical memory with 1GB huge pages

### DIFF
--- a/bootloader/src/main.rs
+++ b/bootloader/src/main.rs
@@ -152,12 +152,12 @@ fn uefi_main(handle: Handle, system_table: SystemTable<Boot>) -> Status {
 
     bootlog!("Kernel entrypoint: {}", addresses.kernel_entry);
 
-    // jump_to_kernel(
-    //     page_mappings.level_4_phys_addr().as_u64(),
-    //     addresses.stack_top.as_u64(),
-    //     addresses.kernel_entry.as_u64(),
-    //     boot_info_ptr,
-    // );
+    jump_to_kernel(
+        page_mappings.level_4_phys_addr().as_u64(),
+        addresses.stack_top.as_u64(),
+        addresses.kernel_entry.as_u64(),
+        boot_info_ptr,
+    );
 
     loop {}
 }

--- a/bootloader/src/main.rs
+++ b/bootloader/src/main.rs
@@ -110,19 +110,6 @@ fn uefi_main(handle: Handle, system_table: SystemTable<Boot>) -> Status {
     let (_, mut memory_map) = system_table.exit_boot_services();
     memory_map.sort();
 
-    // DEBUG: Print memory map
-    for d in memory_map
-        .entries()
-        .filter(|d| d.ty == MemoryType::CONVENTIONAL)
-    {
-        bootlog!(
-            "({:#016x}-{:#016x}) {:?}",
-            d.phys_start,
-            d.phys_start + (PAGE_SIZE * d.page_count),
-            d.ty,
-        )
-    }
-
     let mut frame_allocator = FrameAllocator::new(&memory_map, MIN_BOOT_PHYS_FRAMES);
     bootlog!(
         "Reserved physical memory for boot. ({}-{})",

--- a/bootloader/src/main.rs
+++ b/bootloader/src/main.rs
@@ -4,7 +4,7 @@
 use core::arch::asm;
 use core::panic::PanicInfo;
 
-use common::{BootInfo, PAGE_SIZE};
+use common::BootInfo;
 use loader::{KernelAddresses, LoaderResult};
 use uefi::prelude::*;
 
@@ -18,8 +18,6 @@ mod graphics;
 mod loader;
 mod mappings;
 mod page;
-
-use uefi::table::boot::MemoryType;
 
 use crate::boot_info::create_boot_info;
 use crate::frame::FrameAllocator;

--- a/bootloader/src/main.rs
+++ b/bootloader/src/main.rs
@@ -152,12 +152,12 @@ fn uefi_main(handle: Handle, system_table: SystemTable<Boot>) -> Status {
 
     bootlog!("Kernel entrypoint: {}", addresses.kernel_entry);
 
-    jump_to_kernel(
-        page_mappings.level_4_phys_addr().as_u64(),
-        addresses.stack_top.as_u64(),
-        addresses.kernel_entry.as_u64(),
-        boot_info_ptr,
-    );
+    // jump_to_kernel(
+    //     page_mappings.level_4_phys_addr().as_u64(),
+    //     addresses.stack_top.as_u64(),
+    //     addresses.kernel_entry.as_u64(),
+    //     boot_info_ptr,
+    // );
 
     loop {}
 }

--- a/bootloader/src/mappings.rs
+++ b/bootloader/src/mappings.rs
@@ -1,7 +1,7 @@
 use common::{
     addr::{Page, PageRange, PhysAddr, PhysFrame, VirtPage},
     page::{IntermediatePageTable, PageTable, PageTableEntry},
-    HUGE_PAGE_SIZE_PAGES,
+    HUGE_PAGE_SIZE_BYTES, HUGE_PAGE_SIZE_PAGES,
 };
 use uefi::table::boot::MemoryMap;
 
@@ -147,6 +147,48 @@ impl<'a> Mappings<'a> {
         );
     }
 
+    fn direct_map_huge_page(
+        &mut self,
+        frame_range: PageRange<PhysFrame>,
+        allocator: &mut FrameAllocator,
+    ) {
+        let start_page = frame_range.first().as_direct_mapped();
+        let end_page = frame_range.end().as_direct_mapped();
+
+        let page_range = VirtPage::range_exclusive(start_page, end_page);
+
+        // Make sure everything is aligned correctly.
+        assert!(frame_range.first().base_u64() % HUGE_PAGE_SIZE_BYTES == 0);
+        assert!(frame_range.end().base_u64() % HUGE_PAGE_SIZE_BYTES == 0);
+
+        assert!(page_range.first().base_u64() % HUGE_PAGE_SIZE_BYTES == 0);
+        assert!(page_range.end().base_u64() % HUGE_PAGE_SIZE_BYTES == 0);
+
+        bootlog!(
+            "Direct mapping with huge pages: {} - {}",
+            frame_range,
+            page_range
+        );
+
+        let frame_iter = frame_range.iter().step_by(HUGE_PAGE_SIZE_PAGES as usize);
+        let page_iter = page_range.iter().step_by(HUGE_PAGE_SIZE_PAGES as usize);
+
+        for (frame, page) in frame_iter.zip(page_iter) {
+            bootlog!("Mapping 1GB page {} - {}", frame, page);
+            let level_3_map = self
+                .level_4_map
+                .get_mut_or_insert(page.base_addr(), allocator);
+
+            let new_entry = level_3_map.get_entry_mut(page.base_addr());
+
+            new_entry.set_no_exec(true);
+            new_entry.set_write(true);
+            new_entry.set_present(true);
+            new_entry.set_page_size(true);
+            new_entry.set_addr(frame.base_addr());
+        }
+    }
+
     pub fn map_physical_memory(&mut self, memory_map: &MemoryMap, allocator: &mut FrameAllocator) {
         let highest_segment = memory_map
             .entries()
@@ -165,7 +207,7 @@ impl<'a> Mappings<'a> {
         };
 
         if let Some(middle) = middle {
-            self.direct_map_range(middle, allocator);
+            self.direct_map_huge_page(middle, allocator);
         };
 
         if let Some(end) = end {

--- a/buildscript/build.py
+++ b/buildscript/build.py
@@ -96,6 +96,8 @@ def run_qemu(debug=False):
         "none",
         "-drive",
         f"file=fat:rw:{get_bootimg_path()},format=raw",
+        "-m",
+        "2G",
         "-monitor",
         "stdio",
         "-D",

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -37,6 +37,11 @@ pub const PHYSADDR_SIZE: u8 = 52;
 // This is the number of bits that are used in a virtual address. The upper bits must be sign-extended.
 pub const VIRTADDR_SIZE: u8 = 48;
 
+// Size of the memory covered by a 1 GB huge page.
+pub const HUGE_PAGE_SIZE_BYTES: u64 = 1024 * 1024 * 1024;
+// How many normal 4K pages fit in a 1 GB huge page.
+pub const HUGE_PAGE_SIZE_PAGES: u64 = HUGE_PAGE_SIZE_BYTES / PAGE_SIZE;
+
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RegionType {

--- a/common/src/page.rs
+++ b/common/src/page.rs
@@ -18,6 +18,10 @@ pub struct PageTableEntry {
 impl PageTableEntry {
     const PRESENT_IDX: u8 = 0;
     const WRITE_IDX: u8 = 1;
+    // This is technically not the page size bit for all levels of the paging structures.
+    // Pending a rewrite to use a different type for each level of paging entry, we will just
+    // pinky promise not to use it at the wrong level.
+    const PAGE_SIZE_IDX: u8 = 7;
     const NO_EXEC_IDX: u8 = 63;
     const ADDR_IDX: u8 = 12;
     const ADDR_SIZE: u8 = PHYSADDR_SIZE - PageTableEntry::ADDR_IDX;
@@ -52,6 +56,14 @@ impl PageTableEntry {
 
     pub fn set_no_exec(&mut self, no_exec: bool) {
         self.set_flag(no_exec, PageTableEntry::NO_EXEC_IDX);
+    }
+
+    pub fn page_size(&self) -> bool {
+        self.get_flag(PageTableEntry::PAGE_SIZE_IDX)
+    }
+
+    pub fn set_page_size(&mut self, page_size: bool) {
+        self.set_flag(page_size, PageTableEntry::PAGE_SIZE_IDX);
     }
 
     pub fn addr(&self) -> PhysAddr {


### PR DESCRIPTION
This allows us to boot on systems with lots of memory without blowing all our bootloader memory on page tables.